### PR TITLE
Use `jiro4989/setup-nim-action` `v1.3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           key: "${{ runner.os }}-nimble-${{ hashFiles('**/*.nimble') }}"
           path: "~/.nimble"
-      - uses: "jiro4989/setup-nim-action@v1.3.4"
+      - uses: "jiro4989/setup-nim-action@v1.3"
         with:
           nim-version: '1.4.8'
       - run: nimble --stacktrace:on --linetrace:on build --accept uq


### PR DESCRIPTION
This is both a transition to the "floating" tag, and also an upgrade; at
the time of writing, this dependency is @ `v1.3.15`:

https://github.com/jiro4989/setup-nim-action/releases/tag/v1.3.15